### PR TITLE
add default models expand depth configuration.

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -17,8 +17,9 @@ import (
 // Config stores ginSwagger configuration variables.
 type Config struct {
 	//The url pointing to API definition (normally swagger.json or swagger.yaml). Default is `doc.json`.
-	URL         string
-	DeepLinking bool
+	URL               string
+	DeepLinking       bool
+	ModelsExpandDepth int
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -35,11 +36,19 @@ func DeepLinking(deepLinking bool) func(c *Config) {
 	}
 }
 
+// ModelsExpandDepth set the swagger default models expand depth configuration
+func ModelsExpandDepth(depth int) func(c *Config) {
+	return func(c *Config) {
+		c.ModelsExpandDepth = depth
+	}
+}
+
 // WrapHandler wraps `http.Handler` into `gin.HandlerFunc`.
 func WrapHandler(h *webdav.Handler, confs ...func(c *Config)) gin.HandlerFunc {
 	defaultConfig := &Config{
-		URL:         "doc.json",
-		DeepLinking: true,
+		URL:               "doc.json",
+		DeepLinking:       true,
+		ModelsExpandDepth: 1,
 	}
 
 	for _, c := range confs {
@@ -61,8 +70,9 @@ func CustomWrapHandler(config *Config, h *webdav.Handler) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		type swaggerUIBundle struct {
-			URL         string
-			DeepLinking bool
+			URL               string
+			DeepLinking       bool
+			ModelsExpandDepth int
 		}
 
 		var matches []string
@@ -91,8 +101,9 @@ func CustomWrapHandler(config *Config, h *webdav.Handler) gin.HandlerFunc {
 		switch path {
 		case "index.html":
 			index.Execute(c.Writer, &swaggerUIBundle{
-				URL:         config.URL,
-				DeepLinking: config.DeepLinking,
+				URL:               config.URL,
+				DeepLinking:       config.DeepLinking,
+				ModelsExpandDepth: config.ModelsExpandDepth,
 			})
 		case "doc.json":
 			doc, err := swag.ReadDoc()
@@ -226,7 +237,8 @@ window.onload = function() {
       SwaggerUIBundle.plugins.DownloadUrl
     ],
 	layout: "StandaloneLayout",
-	deepLinking: {{.DeepLinking}}
+	deepLinking: {{.DeepLinking}}, 
+	defaultModelsExpandDepth: {{.ModelsExpandDepth}}
   })
 
   window.ui = ui

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -157,3 +157,11 @@ func TestDeepLinking(t *testing.T) {
 	configFunc(&cfg)
 	assert.Equal(t, expected, cfg.DeepLinking)
 }
+
+func TestModelsExpandDepth(t *testing.T) {
+	expected := 2
+	cfg := Config{}
+	configFunc := ModelsExpandDepth(expected)
+	configFunc(&cfg)
+	assert.Equal(t, expected, cfg.ModelsExpandDepth)
+}


### PR DESCRIPTION
if I have a lot of models in my project, the model section at the bottom of the swagger UI page is will be too long. so I want to ad add default models expand depth configuration to hide the model section in the UI.